### PR TITLE
Update Freemius API file name and function

### DIFF
--- a/freemius-webhook.php
+++ b/freemius-webhook.php
@@ -24,9 +24,9 @@
      * Freemius PHP SDK can be downloaded from GitHub:
      *  https://github.com/Freemius/php-sdk
      */
-    require_once '/path/to/freemius/sdk/Freemius.php';
+    require_once '/path/to/freemius/sdk/FreemiusWordPress.php';
 
-    $fs = new Freemius_Api(
+    $fs = new Freemius_Api_WordPress(
         'plugin',
         'YOUR_PLUGIN_ID',
         'YOUR_PLUGIN_PUBLIC_KEY',


### PR DESCRIPTION
The latest version of Freemius SDK (v2.3.0) has no file called `Freemius.php` in the `sdk` folder and no class called `Freemius_Api`.

It looks like that was changed to `FreemiusWordPress.php` and `Freemius_Api_WordPress` respectively.